### PR TITLE
[PhysicalNodeAddressDto] override equals, hashCode, toString

### DIFF
--- a/commons/src/main/kotlin/com/modernflow/keyvaluestore/dtos/PhysicalNodeAddressDto.kt
+++ b/commons/src/main/kotlin/com/modernflow/keyvaluestore/dtos/PhysicalNodeAddressDto.kt
@@ -3,4 +3,17 @@ package com.modernflow.keyvaluestore.dtos
 data class PhysicalNodeAddressDto(
     val ip: String,
     val port: Int,
-)
+) {
+    override fun hashCode(): Int {
+        return super.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PhysicalNodeAddressDto) return false
+        return ip == other.ip && port == other.port
+    }
+    override fun toString(): String {
+        return "ip = $ip, port = $port"
+    }
+}


### PR DESCRIPTION
* 세개의 함수를 override하여 구현한다

* equals와 hashCode를 사용해서 같은 객체인지 파악하는 경우를 위해 구분지어주고, toString은 필요한 정보만을 출력하기 위해 재정의한다

close: #79